### PR TITLE
Initialize Node proofreader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+log
+*.log
+records

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-This is the very beginning of a project intended to build a tool to help users polish and proofread their English writing, score it, and assist them in improving their writing skills.
+# PolishPal
 
-The brief idea is to build it with Node.js and host it as a worker on Cloudflare.
+This project aims to build a tool that helps users polish and proofread their English writing using AI. The application performs word by word analysis and stores the results for later review.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Obtain an OpenAI API key and set it as an environment variable:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+
+## Usage
+
+Run the proofreader by providing the text to check:
+
+```bash
+npm start -- "This is an example sentence."
+```
+
+The analysis output will be printed to the console and saved under the `records/` directory as a JSON file with a timestamped filename.
+
+If the `OPENAI_API_KEY` environment variable is not provided or if the API call fails, the application will generate a dummy analysis for each word.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "polishpal",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "polishpal",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "openai": "^5.3.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "polishpal",
+  "version": "1.0.0",
+  "description": "This is the very beginning of a project intended to build a tool to help users polish and proofread their English writing, score it, and assist them in improving their writing skills.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node -e \"console.log('No tests yet')\"",
+    "start": "node src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "openai": "^5.3.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,26 @@
+const { proofread } = require('./proofreader');
+const fs = require('fs');
+
+async function main() {
+  const text = process.argv.slice(2).join(' ');
+  if (!text) {
+    console.error('Usage: node src/index.js "<text to proofread>"');
+    process.exit(1);
+  }
+  const analysis = await proofread(text);
+  console.log(JSON.stringify(analysis, null, 2));
+
+  const outDir = 'records';
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir);
+  }
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `${outDir}/analysis-${timestamp}.json`;
+  fs.writeFileSync(filename, JSON.stringify({ text, analysis }, null, 2));
+  console.log(`Analysis saved to ${filename}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/proofreader.js
+++ b/src/proofreader.js
@@ -1,0 +1,31 @@
+const { OpenAI } = require('openai');
+
+async function proofread(text) {
+  if (!process.env.OPENAI_API_KEY) {
+    console.warn('OPENAI_API_KEY not provided, returning dummy analysis');
+    return text.split(/\s+/).map(word => ({ word, comment: 'No analysis (API key missing)' }));
+  }
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful proofreader. For each word in the user text, return a JSON array of objects with keys `word`, `correction`, and `comment`. If the word is correct leave `correction` empty.' },
+        { role: 'user', content: text }
+      ],
+      response_format: { type: 'json_object' }
+    });
+    const content = completion.choices[0].message.content;
+    try {
+      return JSON.parse(content);
+    } catch (err) {
+      console.warn('Failed to parse AI response, returning raw content');
+      return { raw: content };
+    }
+  } catch (err) {
+    console.error('Error calling OpenAI:', err.message);
+    return text.split(/\s+/).map(word => ({ word, comment: 'Error contacting AI' }));
+  }
+}
+
+module.exports = { proofread };


### PR DESCRIPTION
## Summary
- scaffold a Node.js project
- implement basic word-by-word proofreading via OpenAI
- store results under `records/`
- add setup and usage docs
- handle missing API key with a fallback

## Testing
- `npm test`
- `node src/index.js "hello world"`

------
https://chatgpt.com/codex/tasks/task_e_684ffe7f67b0832d8d46f3cc70ab493f